### PR TITLE
fix(settings): add smtp_enabled computed property

### DIFF
--- a/packages/settings.py
+++ b/packages/settings.py
@@ -23,6 +23,11 @@ class SystemSettings(BaseSettings):
     smtp_timeout: int = Field(10, ge=1, description="SMTP bağlantı zaman aşımı (saniye)")
     admin_email: Optional[str] = Field(None, description="Admin e-posta adresi (virgülle ayrılmış birden fazla)")
 
+    @property
+    def smtp_enabled(self) -> bool:
+        """SMTP aktif mi? Hem `smtp_email` hem `smtp_password` dolu olmalı."""
+        return bool(self.smtp_email) and bool(self.smtp_password)
+
     # Slack Bilgileri
     slack_admins: list[str] = Field(..., description="Slack Admin ID listesi")
     slack_startup_channel: Optional[str] = Field(None, description="Slack Startup Channel ID")


### PR DESCRIPTION
## Sorun

`SmtpClient.__init__` ([packages/smtp/client.py:17](packages/smtp/client.py#L17)) SMTP'nin aktif olup olmadığına karar vermek için `get_settings().smtp_enabled` okuyor. Ama `SystemSettings` sınıfında böyle bir field tanımlı değil — `SmtpClient()` çağıran herkes `AttributeError` alıyor.

```python
if not get_settings().smtp_enabled:   # AttributeError
    raise RuntimeError(...)
```

## Çözüm

`SystemSettings`'e küçük bir `@property` eklendi: hem `smtp_email` hem `smtp_password` dolu olduğunda `True` döner. `Optional[str]` field'lar mevcut şekilde kalıyor; bu sadece türetilmiş tek-noktada kontrol sağlıyor.

```python
@property
def smtp_enabled(self) -> bool:
    return bool(self.smtp_email) and bool(self.smtp_password)
```

`bool("")` ve `bool(None)` ikisi de `False` döner, dolayısıyla env'den boş string gelse bile property doğru cevap verir.

## Test

```python
from packages.settings import get_settings
s = get_settings()
print(type(s.smtp_enabled).__name__, s.smtp_enabled)
# bool True   (her iki SMTP env değişkeni dolu olduğunda)
```

## Kapsam

- 1 dosya, 5 satır
- Mevcut field'lara dokunulmadı
- Migration veya schema değişikliği yok

## Sıralama Notu

`feature/event-service` branch'i bu property'yi kullanan bir bug fix içeriyor (`services/event_service/utils/email.py` içinde `SmtpClient(email=..., ...)` yanlış çağrısı). Bu PR **önce** merge edilmeli, sonra feature/event-service `dev`'e rebase edilip merge'lenmeli — aksi halde feature merge'lendiği anda email.py runtime hatası verir.